### PR TITLE
add notes from the first organiser meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Admin
 
-This repository contains everything you need to know about GoSheffield.
-
-### Summary
-
 GoSheffield is a non-profit monthly meetup in Sheffield about the [Go Programming  
 Language](https://golang.org/). Organised by the local community, we focus  
 on short technical talks and fostering the growth of Go in the area. 
@@ -23,14 +19,12 @@ Our events follow the Go Community [Code of Conduct](https://golang.org/conduct)
 * [Slack](https://gophers.slack.com/messages/sheffield), where we chat with
   other members (join [here](https://invite.slack.golangbridge.org/))
 
-### Past Meetups
+### Records
 
-* [January 2019](meetups/all_meetups.md#01.2019)
-* [December 2018](meetups/all_meetups.md#12.2018)
-* [November 2018](meetups/all_meetups.md#11.2018)
-* [October 2018](meetups/all_meetups.md#10.2018)
+* [Past meetups](meetups/all_meetups.md)
+* [Organiser meetings notes](meeting_notes/)
 
 ### Speaking at GoSheffield
 
-* We help choose and prepare Go-related topics
-* Register your interest at [GoSheffield Speakers Registration Form](https://goo.gl/forms/1VAAejXiA69bXXCP2)
+* We help refine your topic and presentation
+* Register your interest via [this short form](https://goo.gl/forms/1VAAejXiA69bXXCP2)!

--- a/meeting_notes/2019-02-02.md
+++ b/meeting_notes/2019-02-02.md
@@ -1,0 +1,76 @@
+## First organiser meetup
+
+Present:
+
+* [Mike Kaperys](https://github.com/kaperys)
+* [Wei Zhang](https://github.com/weizhang9)
+* [Daniel Martí](https://github.com/mvdan)
+
+#### Roles
+
+* Mike: money and sponsorships, and expenses
+* Wei: talks and new speakers, and twitter
+* Dan: running each event, and planning future meetups
+
+We need to add mike onto the bank account. Securely give Wei the Twitter
+password, as the TweetDeck teams don't work on mobile.
+
+#### 3-4 sponsors in the long term
+
+Monzo, Uaccount, and hopefully Utility Warehouse as long-term sponsors.
+
+CloudlFlare as backup since they require more paperwork.
+
+#### Talking to members to get new speakers
+
+Encourage people to join Slack. Perhaps send one email via meetup each month.
+
+Create a form to make it easier for new speakers to come forward.
+
+#### Growing the meetup
+
+Current constraints:
+
+* venue: max of 30-35 at tech parks
+* sponsors: current income covers up to ~50 attendees
+
+Spending more sponsor money:
+
+* adding drinks (beer, tea, soft drinks)
+* travel reimbursement for speakers from outside Sheffield
+* reimbursements require receipts/tickets
+
+Sustainable prizes:
+
+* one drink for each speaker (beer, tea, milkshake)
+* more sponsored quiz/random prizes (swag, books)
+
+#### Workshops
+
+Ask at next meetup who would come to both in a single month.
+
+Talk to bigger venues with sockets and tables in sheffield, like SkyBet.
+
+#### GitHub
+
+Try to copy GLUG's admin repo with general info.
+
+Start collecting data on past meetups.
+
+#### Current recurring costs
+
+For ~30 people per meetup:
+
+* ~80 gbp in pizza
+* ~14 gbp in meetup.com
+
+#### "Far" future wishlist
+
+Start recording talks; buy audio (and video?) equipment.
+
+Holding workshops regularly, if there's interest and time.
+
+Growing the meetup past ~50 attendees after summer.
+
+Being fully transparent, including finances.
+


### PR DESCRIPTION
The notes are as they were taken initially, but slightly polished.

While at it, some README cleanup:

* The first tiny section is kinda pointless.
* We can't list every past meetup in the README; that doesn't scale.
* Simplify the wording for the speaker form.